### PR TITLE
Fix Neha email link

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -231,7 +231,7 @@ const AboutPage = ({ data }) => (
             </div>
             <div className="team_details">
               <h2>Neha Sharma</h2>
-              <span><a href="neha@terran.io">neha@terran.io</a></span>
+              <span><a href="mailto:neha@terran.io">neha@terran.io</a></span>
             </div>
             <p>Neha is committed to tapping into collective insight and foresight in order to restore and regenerate our relationship with the planet. She does this through strategy work and impactful partnerships. Currently, she is focused on improving energy efficiency and intelligence in the built environment, exercising facilitation for group alignment, and bridge-building between disparate networks & nodes. She involves herself in many side projects and shticks to ensure that her soul is always activated. Inquiries of this season include: What will allow beings to cooperate harmoniously across scales? How do we ensure all voices and stakeholders are represented in conversations about building the future?</p>
           </li>


### PR DESCRIPTION
Hey @tibetsprague @cpolitano @brodeur, I took a look at your website's code on GitHub, and enjoyed learning a little about your organization. I know this code base is quite stale, but wanted to offer a tiny fix for a broken email link on your About page. Specifically, Neha's email link is missing a mailto. This pull request fixes the link, and no more. Dozens of folks have probably wondered about that 404 when they tried to email Neha.  

All the best, [Josh](https://github.com/joshagilend) at [Agilend](https://github.com/Agilend)